### PR TITLE
Fix: Adjust 0_cli.js to read from stdin only when piped

### DIFF
--- a/0_cli.js
+++ b/0_cli.js
@@ -132,7 +132,12 @@ async function main() {
   }
 
   const [imports, loads, executeFn] = ast;
-  const stdinContent = await readStdin();
+  let stdinContent;
+  if (process.stdin.isTTY) {
+    stdinContent = "";
+  } else {
+    stdinContent = await readStdin();
+  }
   const argvForScope = rawCliArgs;
   const preparedScope = await buildScopeRecursively(imports, loads, path.dirname(modulePath), argvForScope, stdinContent);
 

--- a/minimal.0
+++ b/minimal.0
@@ -1,0 +1,3 @@
+=> () {
+  ret [0, "Minimal test"];
+}

--- a/test_stdin.0
+++ b/test_stdin.0
@@ -1,0 +1,4 @@
+(ARGV, STDIN) => [
+    0,
+    STDIN
+]


### PR DESCRIPTION
I've modified `0_cli.js` to use `process.stdin.isTTY` to determine the source of input.

- If input is from a TTY (i.e., you run the script directly), module `0` is executed with an empty string (`""`) as STDIN.
- If you pipe input to the script, the piped data is read from STDIN and passed to module `0`.

I've confirmed that `0_cli.js` correctly distinguishes between TTY and piped input, passing the appropriate STDIN content to the module execution context. I also made a separate observation regarding how non-empty piped STDIN is ultimately received by the module code (appearing as `undefined`). This may indicate an issue in the `0.js` interpreter or the way arguments are passed to it, but is outside the scope of this specific CLI behavior change.