### PR TITLE
Refatora o combinador 'sequência' para o estilo de 'símbolo'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
- Altera o combinador `sequência` para retornar um objeto com um método `avaliar`, assim como `símbolo`.
- O método `avaliar` da `sequência` agora retorna um objeto `{valor, resto}`.
- Introduz uma função auxiliar `rodar_analisador` para unificar a forma como os diferentes tipos de analisadores (função ou objeto) são executados, padronizando a saída para `[status, valor, resto]` para uso interno.
- Atualiza todos os outros combinadores (`alternativa`, `opcional`, `vários`, `transformar`) para usar `rodar_analisador`.
- Refatora as implementações de `alternativa` e `vários` para serem iterativas em vez de recursivas.