### PR TITLE
feat: Adiciona instalação via curl e atualiza LEIAME

### DIFF
--- a/LEIAME.md
+++ b/LEIAME.md
@@ -10,6 +10,16 @@ O nome 0 foi escolhido por sua simplicidade e universalidade. O zero é um conce
 
 Esperamos que a 0 se torne uma ferramenta valiosa para desenvolvedores ao redor do mundo, promovendo a eficiência e a clareza no desenvolvimento de software.
 
+## Instalação
+
+Para instalar a Linguagem 0, você pode usar o seguinte comando, que baixa e executa o script de instalação:
+
+```bash
+curl -sSL https://cdn.jsdelivr.net/gh/Nuffem/0@main/install.sh | bash
+```
+
+O script instala o interpretador e o adiciona ao seu PATH. Se o diretório `~/.local/bin` não estiver no seu PATH, o script fornecerá instruções sobre como adicioná-lo.
+
 ## Sintaxe
 A sintaxe é definida diretamente no interpretador [0.js](https://github.com/Nuffem/0/blob/main/0.js) e pode ser compreendida mais facilmente com o auxílio dos [exemplos](https://github.com/Nuffem/0/blob/main/exemplos.md).
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# Cores para a saída
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # Sem cor
+
+# Nomes e URLs
+CMD_NAME="0"
+INTERPRETER_NAME="0_node.js"
+REPO_USER="Nuffem"
+REPO_NAME="0"
+INTERPRETER_URL="https://cdn.jsdelivr.net/gh/$REPO_USER/$REPO_NAME@main/$INTERPRETER_NAME"
+
+# Diretórios de instalação
+BIN_DIR="$HOME/.local/bin"
+LIB_DIR="$HOME/.local/lib/zero-lang"
+CMD_PATH="$BIN_DIR/$CMD_NAME"
+INTERPRETER_PATH="$LIB_DIR/$INTERPRETER_NAME"
+
+
+echo "Instalando a Linguagem 0..."
+
+# 1. Cria os diretórios de instalação se não existirem
+echo "Verificando os diretórios de instalação..."
+mkdir -p "$BIN_DIR"
+mkdir -p "$LIB_DIR"
+
+# 2. Baixa o interpretador
+echo "Baixando o interpretador de '$INTERPRETER_URL'..."
+if command -v curl >/dev/null 2>&1; then
+    curl -sSL "$INTERPRETER_URL" -o "$INTERPRETER_PATH"
+elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$INTERPRETER_PATH" "$INTERPRETER_URL"
+else
+    echo "${YELLOW}Erro: Você precisa ter 'curl' ou 'wget' instalado para baixar o interpretador.${NC}"
+    exit 1
+fi
+
+if [ ! -s "$INTERPRETER_PATH" ]; then
+    echo "${YELLOW}Erro: Falha ao baixar o interpretador. O arquivo está vazio ou o download falhou.${NC}"
+    exit 1
+fi
+
+echo "${GREEN}Interpretador baixado com sucesso para '$INTERPRETER_PATH'.${NC}"
+
+# 3. Cria o script de wrapper para o comando '0'
+echo "Criando o comando '$CMD_NAME' em '$CMD_PATH'"
+cat > "$CMD_PATH" << EOL
+#!/bin/sh
+# Wrapper para o interpretador da Linguagem 0
+exec node "$INTERPRETER_PATH" "\$@"
+EOL
+
+# 4. Torna o comando executável
+chmod +x "$CMD_PATH"
+
+echo "${GREEN}Comando '$CMD_NAME' criado com sucesso.${NC}"
+
+# 5. Verifica se o diretório de instalação está no PATH
+if ! echo "$PATH" | grep -q "$BIN_DIR"; then
+    echo "\n${YELLOW}Atenção: O diretório '$BIN_DIR' não está no seu PATH.${NC}"
+    echo "Para usar o comando '0' de qualquer lugar, adicione a seguinte linha ao seu arquivo de configuração do shell (ex: ~/.bashrc, ~/.zshrc):"
+    echo "\n  export PATH=\"\$HOME/.local/bin:\$PATH\"\n"
+    echo "Depois, reinicie seu shell ou execute 'source ~/.bashrc' (ou o arquivo correspondente)."
+else
+    echo "\nO diretório '$BIN_DIR' já está no seu PATH."
+fi
+
+echo "\n${GREEN}Instalação da Linguagem 0 concluída!${NC}"
+echo "Use o comando '0 seu_arquivo.0' para executar seus programas."


### PR DESCRIPTION
- Atualiza o script `install.sh` para ser compatível com CDN, permitindo a instalação via `curl`. O script agora baixa o interpretador `0_node.js` de jsdelivr em vez de depender de um arquivo local.
- Adiciona uma seção "Instalação" ao `LEIAME.md` com o comando para instalar a linguagem usando `curl`.